### PR TITLE
Set ecmaVersion to 2021

### DIFF
--- a/configs/core.js
+++ b/configs/core.js
@@ -3,7 +3,7 @@
 module.exports = {
     reportUnusedDisableDirectives: true,
     parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: 2021,
         sourceType: 'script',
         ecmaFeatures: {
             jsx: false,


### PR DESCRIPTION
Numeric seperators require ES 2021.