### PR TITLE
Set no-non-null-assertion to "error"

### DIFF
--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -249,7 +249,7 @@ module.exports = {
         '@typescript-eslint/no-magic-numbers': ['off'],
         '@typescript-eslint/no-namespace': ['off'],
         '@typescript-eslint/no-non-null-asserted-optional-chain': ['error'],
-        '@typescript-eslint/no-non-null-assertion': ['off'],
+        '@typescript-eslint/no-non-null-assertion': ['error'],
         '@typescript-eslint/no-parameter-properties': ['off'],
         '@typescript-eslint/no-type-alias': ['off'],
         '@typescript-eslint/no-unnecessary-boolean-literal-compare': ['error'],


### PR DESCRIPTION
Using non-null assertions is often a sign that code is not fully type-safe and leads to runtime leaks where the compiler should guard us from. Therefore [no-non-null-assertion](https://typescript-eslint.io/rules/no-non-null-assertion/) should be set to `error`.